### PR TITLE
recording all ping responses

### DIFF
--- a/krl/org.sovrin.aca.trust_ping.krl
+++ b/krl/org.sovrin.aca.trust_ping.krl
@@ -88,6 +88,7 @@ ruleset org.sovrin.aca.trust_ping {
       raise didcomm event "new_ssi_agent_wire_message" attributes {
         "serviceEndpoint": se, "packedMessage": pm
       }
+      ent:lastPingResponse := null
     }
   }
 }


### PR DESCRIPTION
Every time a ping is sent, the last response is set to null so that if it does not receive a response it will appear as null otherwise the response will be set on the  handle_trust_ping_ping_response rule.

<!---
@huboard:{"order":4.0,"milestone_order":4,"custom_state":""}
-->
