### PR TITLE
Fix issue #26

### DIFF
--- a/NEXT/io.picolabs.aca.connections.krl
+++ b/NEXT/io.picolabs.aca.connections.krl
@@ -162,7 +162,7 @@ ruleset io.picolabs.aca.connections {
       service = connection{["DIDDoc","service"]}
         .filter(function(x){
           x{"type"}=="IndyAgent"
-          && x{"id"}.match(their_did+";indy")
+          && x{"id"}.match("^"+their_did)
         }).head()
       se = service{"serviceEndpoint"}
       their_rks = service{"routingKeys"}.defaultsTo([])


### PR DESCRIPTION
Needed to remove the static ";indy" suffix and simplified the comparison to match if the service id begins with the DID provided.